### PR TITLE
Correcting SQLite path to db file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN chmod +x entrypoint.sh
 EXPOSE 5000
 
 ENV PORT=5000
-ENV SQLITE_DB_PATH=sqlite:///app.db
+ENV SQLITE_DB_PATH=sqlite:////app/app.db
 
 CMD ["./entrypoint.sh"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,8 @@ def create_app():
     app = Flask(__name__)
     app.secret_key = 'temp'
 
-    db_path = os.getenv('SQLITE_DB_PATH', 'sqlite:///app.db')
+    default_path = os.path.join(os.path.dirname(__file__), 'app.db')
+    db_path = os.getenv('SQLITE_DB_PATH', f"sqlite:///{default_path}")
     app.config['SQLALCHEMY_DATABASE_URI'] = db_path
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     


### PR DESCRIPTION
Changes environment variable from `sqlite:///app.db` to `sqlite:////app/app.db`. This allows Docker-based deployments to use an absolute path (/app/app.db) inside the container, ensuring the SQLite file is created and writable while the application still falls back to a local path for development.

Also changed the default path to work similarly so it can still set up the app via windows, as well as linux.
```
default_path = os.path.join(os.path.dirname(__file__), 'app.db')
db_path = os.getenv('SQLITE_DB_PATH', f"sqlite:///{default_path}")
```